### PR TITLE
Omit building examples and pass option for using doubles

### DIFF
--- a/recipes/edyn/all/conanfile.py
+++ b/recipes/edyn/all/conanfile.py
@@ -37,6 +37,7 @@ class EdynConan(ConanFile):
         return {
             "gcc": "9.3", # GCC 9.3 started supporting attributes in constructor arguments
             "clang": "8",
+            "apple-clang": "10",
             "Visual Studio": "16",
             "msvc": "192"
         }
@@ -64,6 +65,9 @@ class EdynConan(ConanFile):
     def generate(self):
         tc = CMakeToolchain(self)
         tc.variables["EDYN_INSTALL"] = True
+        tc.variables["EDYN_BUILD_EXAMPLES"] = False
+        if self.options.floating_type == "double":
+            tc.variables["EDYN_CONFIG_DOUBLE"] = True
         tc.generate()
 
         deps = CMakeDeps(self)

--- a/recipes/edyn/all/test_package/CMakeLists.txt
+++ b/recipes/edyn/all/test_package/CMakeLists.txt
@@ -1,6 +1,6 @@
-cmake_minimum_required(VERSION 3.1)
+cmake_minimum_required(VERSION 3.8)
 
-project(test_package CXX)
+project(test_package LANGUAGES CXX)
 
 find_package(Edyn REQUIRED CONFIG)
 

--- a/recipes/edyn/all/test_package/conanfile.py
+++ b/recipes/edyn/all/test_package/conanfile.py
@@ -5,9 +5,13 @@ from conan.tools.cmake import CMake
 class TestPackageConan(ConanFile):
     settings = "os", "arch", "compiler", "build_type"
     generators = "CMakeDeps", "CMakeToolchain"
+    test_type = "explicit"
 
     def layout(self):
         layout.cmake_layout(self)
+
+    def requirements(self):
+        self.requires(self.tested_reference_str)
 
     def build(self):
         cmake = CMake(self)
@@ -15,5 +19,5 @@ class TestPackageConan(ConanFile):
         cmake.build()
 
     def test(self):
-        if not build.cross_building(self):
+        if build.can_run(self):
             self.run("test_package", run_environment=True)


### PR DESCRIPTION
Examples weren't building properly with conan, and shouldn't be built in conan center pipelines anyway
Floating type option was never being passed to build, so added that
Few more changes to test_package conanfile for more Conan 2.0 conformance too