### PR TITLE
Block failing config

### DIFF
--- a/recipes/edyn/all/conanfile.py
+++ b/recipes/edyn/all/conanfile.py
@@ -49,6 +49,8 @@ class EdynConan(ConanFile):
             del self.options.fPIC
 
     def validate(self):
+        if self.options.shared and self.settings.compiler == "gcc" and Version(self.settings.compiler.version) == "11" and self.settings.build_type == "Release" and self.settings.compiler.libcxx == "libstdc++11":
+            raise ConanInvalidConfiguration(f"{self.ref} does not build in C3i as shared with gcc-11 in release using libstdc++11. Please submit a PR to fix this https://github.com/conan-io/conan-center-index/pull/13562#issuecomment-1284854656")
         if self.settings.compiler.get_safe("cppstd"):
             check_min_cppstd(self, 17)
         check_min_vs(self, 192)

--- a/recipes/edyn/all/test_package/conanfile.py
+++ b/recipes/edyn/all/test_package/conanfile.py
@@ -2,6 +2,7 @@ from conan import ConanFile
 from conan.tools.build import can_run
 from conan.tools.layout import cmake_layout
 from conan.tools.cmake import CMake
+import os
 
 class TestPackageConan(ConanFile):
     settings = "os", "arch", "compiler", "build_type"
@@ -21,4 +22,5 @@ class TestPackageConan(ConanFile):
 
     def test(self):
         if can_run(self):
-            self.run("test_package", run_environment=True)
+            bin_path = os.path.join(self.cpp.build.bindirs[0], "test_package")
+            self.run(bin_path, env="conanrun")


### PR DESCRIPTION
Add validate conditions to block the config that is failing on conan center CI.
